### PR TITLE
feat: decouple operator and database image workflows

### DIFF
--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -62,6 +62,10 @@ inputs:
     description: 'Optional gateway image override for the cluster'
     required: false
     default: ''
+  documentdb-image-tag:
+    description: 'Tag for documentdb/gateway images (defaults to image-tag if not set, for backward compat)'
+    required: false
+    default: ''
   # GitHub configuration
   github-token:
     description: 'GitHub token for accessing packages'
@@ -225,24 +229,28 @@ runs:
       run: |
         # Resolve early so kind-load and deploy steps both use the same refs.
         # Priority: explicit input override > external manifest tag > local build tag.
+        # Database images may use a different tag than operator images (decoupled versioning).
+        DOCDB_TAG="${{ inputs.documentdb-image-tag || inputs.image-tag }}"
+
         if [[ -n "${{ inputs.documentdb-image }}" ]]; then
           DOCDB_IMAGE="${{ inputs.documentdb-image }}"
         elif [[ "${{ inputs.use-external-images }}" == "true" ]]; then
-          DOCDB_IMAGE="ghcr.io/${{ inputs.repository-owner }}/documentdb-kubernetes-operator/documentdb:${{ inputs.image-tag }}"
+          DOCDB_IMAGE="ghcr.io/${{ inputs.repository-owner }}/documentdb-kubernetes-operator/documentdb:${DOCDB_TAG}"
         else
-          DOCDB_IMAGE="ghcr.io/${{ inputs.repository-owner }}/documentdb-kubernetes-operator/documentdb:${{ inputs.image-tag }}-${{ inputs.architecture }}"
+          DOCDB_IMAGE="ghcr.io/${{ inputs.repository-owner }}/documentdb-kubernetes-operator/documentdb:${DOCDB_TAG}-${{ inputs.architecture }}"
         fi
 
         if [[ -n "${{ inputs.gateway-image }}" ]]; then
           GW_IMAGE="${{ inputs.gateway-image }}"
         elif [[ "${{ inputs.use-external-images }}" == "true" ]]; then
-          GW_IMAGE="ghcr.io/${{ inputs.repository-owner }}/documentdb-kubernetes-operator/gateway:${{ inputs.image-tag }}"
+          GW_IMAGE="ghcr.io/${{ inputs.repository-owner }}/documentdb-kubernetes-operator/gateway:${DOCDB_TAG}"
         else
-          GW_IMAGE="ghcr.io/${{ inputs.repository-owner }}/documentdb-kubernetes-operator/gateway:${{ inputs.image-tag }}-${{ inputs.architecture }}"
+          GW_IMAGE="ghcr.io/${{ inputs.repository-owner }}/documentdb-kubernetes-operator/gateway:${DOCDB_TAG}-${{ inputs.architecture }}"
         fi
 
         echo "DOCUMENTDB_IMAGE_RESOLVED=$DOCDB_IMAGE" >> $GITHUB_ENV
         echo "GATEWAY_IMAGE_RESOLVED=$GW_IMAGE" >> $GITHUB_ENV
+        echo "DOCDB_IMAGE_TAG=${DOCDB_TAG}" >> $GITHUB_ENV
         echo "Resolved DocumentDB image: $DOCDB_IMAGE"
         echo "Resolved Gateway image: $GW_IMAGE"
 
@@ -462,30 +470,25 @@ runs:
           fi
           
           # Install the operator using the platform-specific local chart with image tag overrides
-          if [[ "$CERT_MANAGER_READY" == "true" ]]; then
-            helm install documentdb-operator ./documentdb-chart \
-              --namespace ${{ inputs.operator-namespace }} \
-              --create-namespace \
-              --set documentDbVersion="$LOCAL_IMAGE_TAG" \
-              --set image.documentdbk8soperator.tag="$LOCAL_IMAGE_TAG" \
-              --set image.sidecarinjector.tag="$LOCAL_IMAGE_TAG" \
-              --set image.documentdbk8soperator.pullPolicy=IfNotPresent \
-              --set image.sidecarinjector.pullPolicy=IfNotPresent \
-              --set image.walreplica.pullPolicy=IfNotPresent \
-              --wait --timeout=15m
-          else
-            helm install documentdb-operator ./documentdb-chart \
-              --namespace ${{ inputs.operator-namespace }} \
-              --create-namespace \
-              --set documentDbVersion="$LOCAL_IMAGE_TAG" \
-              --set image.documentdbk8soperator.tag="$LOCAL_IMAGE_TAG" \
-              --set image.sidecarinjector.tag="$LOCAL_IMAGE_TAG" \
-              --set image.documentdbk8soperator.pullPolicy=IfNotPresent \
-              --set image.sidecarinjector.pullPolicy=IfNotPresent \
-              --set image.walreplica.pullPolicy=IfNotPresent \
-              --values /tmp/values-override.yaml \
-              --wait --timeout=15m
+          # Operator/sidecar use the operator track tag (LOCAL_IMAGE_TAG).
+          # Database images (documentdb/gateway) use DOCDB_IMAGE_TAG (may differ from operator tag).
+          HELM_ARGS=(
+            --namespace ${{ inputs.operator-namespace }}
+            --create-namespace
+            --set documentDbVersion="$LOCAL_IMAGE_TAG"
+            --set image.documentdbk8soperator.tag="$LOCAL_IMAGE_TAG"
+            --set image.sidecarinjector.tag="$LOCAL_IMAGE_TAG"
+            --set image.documentdbk8soperator.pullPolicy=IfNotPresent
+            --set image.sidecarinjector.pullPolicy=IfNotPresent
+            --set image.walreplica.pullPolicy=IfNotPresent
+            --wait --timeout=15m
+          )
+
+          if [[ "$CERT_MANAGER_READY" != "true" ]]; then
+            HELM_ARGS+=(--values /tmp/values-override.yaml)
           fi
+
+          helm install documentdb-operator ./documentdb-chart "${HELM_ARGS[@]}"
         else
           echo "❌ Platform-specific Helm chart artifact not found: $EXPECTED_CHART_FILE"
           echo "Available files in chart artifact directory:"

--- a/.github/workflows/build_documentdb_images.yml
+++ b/.github/workflows/build_documentdb_images.yml
@@ -1,0 +1,257 @@
+name: RELEASE - Build DocumentDB Candidate Images
+
+# Builds documentdb extension and gateway images from upstream documentdb/documentdb .deb packages.
+# These images follow the DATABASE version track (documentDbVersion in values.yaml).
+# For operator/sidecar images, see build_operator_images.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      documentdb_ref:
+        description: 'DocumentDB repo ref (tag, branch, or commit SHA) for building packages'
+        required: false
+        default: 'main'
+      version:
+        description: 'Image version tag override (auto-detected from source if empty)'
+        required: false
+        default: ''
+
+  repository_dispatch:
+    types: [documentdb-release]
+
+permissions:
+  packages: write
+  contents: read
+  id-token: write
+
+env:
+  DOCUMENTDB_REPO: documentdb/documentdb
+  DOCUMENTDB_REPO_REF: ${{ github.event.inputs.documentdb_ref || github.event.client_payload.ref || 'main' }}
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Build DocumentDB extension and gateway deb packages (per-arch)
+  # ---------------------------------------------------------------------------
+  build-packages:
+    name: Build Packages (${{ matrix.arch }})
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
+    outputs:
+      documentdb_version: ${{ steps.version.outputs.documentdb_version }}
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+    steps:
+    - name: Checkout documentdb source
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ env.DOCUMENTDB_REPO }}
+        ref: ${{ env.DOCUMENTDB_REPO_REF }}
+
+    - name: Extract version from source
+      id: version
+      run: |
+        DOCDB_VERSION=$(grep -E "^default_version" pg_documentdb_core/documentdb_core.control \
+          | sed -E "s/.*'([0-9]+\.[0-9]+-[0-9]+)'.*/\1/" | sed "s/-/./g")
+        echo "documentdb_version=$DOCDB_VERSION" >> $GITHUB_OUTPUT
+        echo "DocumentDB version: $DOCDB_VERSION"
+
+    - name: Determine image tag
+      id: tag
+      run: |
+        # Use explicit version input if provided, otherwise auto-detect from source
+        VERSION="${{ github.event.inputs.version || github.event.client_payload.version }}"
+        if [[ -z "$VERSION" ]]; then
+          VERSION="${{ steps.version.outputs.documentdb_version }}"
+        fi
+        IMAGE_TAG="${VERSION}-test"
+        echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+        echo "Image tag: $IMAGE_TAG"
+
+    - name: Build extension deb (PG18)
+      run: ./packaging/build_packages.sh --os deb13 --pg 18 --output-dir packages
+
+    - name: Build gateway deb
+      # Gateway is a pure Rust binary; PG version is a passthrough and does not affect the output.
+      # Using pg 17 matches the upstream documentdb repo convention (gateway built once, not per-PG).
+      run: ./packaging/build_gateway_packages.sh --os deb13 --pg 17 --output-dir packages
+
+    - name: Upload packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: documentdb-packages-${{ matrix.arch }}
+        path: packages/*.deb
+        retention-days: 1
+        if-no-files-found: error
+        compression-level: 0
+
+    - name: Upload gateway runtime files
+      if: matrix.arch == 'amd64'
+      uses: actions/upload-artifact@v4
+      with:
+        name: gateway-runtime-files
+        path: |
+          scripts/utils.sh
+          pg_documentdb_gw/SetupConfiguration.json
+        retention-days: 1
+        if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # Build and push documentdb + gateway images (per-arch)
+  # ---------------------------------------------------------------------------
+  build-and-push:
+    name: Build and Push ${{ matrix.image.name }} (${{ matrix.arch }})
+    needs: [build-packages]
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        image:
+          - name: documentdb
+            dockerfile: .github/dockerfiles/Dockerfile_extension
+          - name: gateway
+            dockerfile: .github/dockerfiles/Dockerfile_gateway_deb
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
+    env:
+      IMAGE_TAG: ${{ needs.build-packages.outputs.image_tag }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Download packages
+      uses: actions/download-artifact@v4
+      with:
+        name: documentdb-packages-${{ matrix.arch }}
+        path: packages/
+
+    - name: Download gateway runtime files
+      if: matrix.image.name == 'gateway'
+      uses: actions/download-artifact@v4
+      with:
+        name: gateway-runtime-files
+        path: gateway-runtime/
+
+    - name: Prepare gateway build context
+      if: matrix.image.name == 'gateway'
+      run: |
+        set -e
+        mkdir -p gateway-context/packages gateway-context/scripts gateway-context/pg_documentdb_gw
+        cp packages/*gateway*.deb gateway-context/packages/
+        cp gateway-runtime/scripts/utils.sh gateway-context/scripts/
+        cp gateway-runtime/pg_documentdb_gw/SetupConfiguration.json gateway-context/pg_documentdb_gw/
+        cp ${{ github.workspace }}/.github/dockerfiles/gateway_entrypoint.sh gateway-context/scripts/
+        ls gateway-context/packages/*.deb || { echo "ERROR: Gateway deb not found"; exit 1; }
+
+    - name: Login to GHCR
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+    - name: Build and Push ${{ matrix.image.name }} (${{ matrix.arch }})
+      run: |
+        set -euo pipefail
+        TAG=${{ env.IMAGE_TAG }}-${{ matrix.arch }}
+        IMAGE=ghcr.io/${{ github.repository }}/${{ matrix.image.name }}:$TAG
+
+        BUILD_ARGS=""
+        BUILD_CONTEXT="."
+
+        case "${{ matrix.image.name }}" in
+          documentdb)
+            DEB_FILE=$(ls packages/ | grep -E 'postgresql.*documentdb.*\.deb' | grep -v dbgsym | head -1)
+            if [[ -z "$DEB_FILE" ]]; then
+              echo "ERROR: No DocumentDB extension .deb found in packages/" >&2
+              ls -la packages/ >&2
+              exit 1
+            fi
+            echo "Using deb: $DEB_FILE"
+            BUILD_ARGS="--build-arg PG_MAJOR=18 --build-arg DEB_PACKAGE_REL_PATH=packages/$DEB_FILE"
+            ;;
+          gateway)
+            GW_DEB=$(ls gateway-context/packages/ | grep -E 'gateway.*\.deb' | head -1)
+            if [[ -z "$GW_DEB" ]]; then
+              echo "ERROR: No gateway .deb found in gateway-context/packages/" >&2
+              ls -la gateway-context/packages/ >&2
+              exit 1
+            fi
+            echo "Using deb: $GW_DEB"
+            BUILD_ARGS="--build-arg GATEWAY_DEB_REL_PATH=packages/$GW_DEB"
+            BUILD_CONTEXT="gateway-context"
+            ;;
+        esac
+
+        docker build $BUILD_ARGS \
+          -t $IMAGE \
+          -f ${{ matrix.image.dockerfile }} $BUILD_CONTEXT
+        docker push $IMAGE
+
+  # ---------------------------------------------------------------------------
+  # Create multi-arch manifests, sign, and verify
+  # ---------------------------------------------------------------------------
+  create-manifest:
+    name: Create, Push, Sign & Verify Manifest (${{ matrix.image }})
+    strategy:
+      matrix:
+        image: [documentdb, gateway]
+    runs-on: ubuntu-22.04
+    needs: [build-packages, build-and-push]
+    env:
+      IMAGE_TAG: ${{ needs.build-packages.outputs.image_tag }}
+    steps:
+    - name: Login to GHCR
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+    - name: Create and Push Manifest
+      run: |
+        docker manifest create ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }} \
+          --amend ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}-amd64 \
+          --amend ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}-arm64
+        docker manifest push ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}
+
+    - name: Install cosign
+      uses: sigstore/cosign-installer@main
+
+    - name: Sign manifest (keyless)
+      run: |
+        DIGEST=$(docker buildx imagetools inspect ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }} \
+          | awk '/^Digest:/ { print $2 }')
+        echo "Signing manifest-list@${DIGEST}"
+        cosign sign ghcr.io/${{ github.repository }}/${{ matrix.image }}@${DIGEST} -y
+
+    - name: Verify manifest signature (keyless)
+      run: |
+        DIGEST=$(docker buildx imagetools inspect ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }} \
+          | awk '/^Digest:/ { print $2 }')
+        cosign verify \
+          --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/build_documentdb_images.yml@${{ github.ref }}" \
+          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+          ghcr.io/${{ github.repository }}/${{ matrix.image }}@${DIGEST}
+
+  # ---------------------------------------------------------------------------
+  # Summary
+  # ---------------------------------------------------------------------------
+  summary:
+    name: Build Summary
+    runs-on: ubuntu-22.04
+    needs: [build-packages, create-manifest]
+    if: always()
+    steps:
+    - name: Summary
+      run: |
+        echo "## DocumentDB Image Build Summary" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- **DocumentDB Version**: \`${{ needs.build-packages.outputs.documentdb_version }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Image Tag**: \`${{ needs.build-packages.outputs.image_tag }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Source Ref**: \`${{ env.DOCUMENTDB_REPO_REF }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Images**: documentdb, gateway" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "To release these images, run \`release_documentdb_images.yml\` with:" >> $GITHUB_STEP_SUMMARY
+        echo "- candidate_version: \`${{ needs.build-packages.outputs.image_tag }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- version: \`${{ needs.build-packages.outputs.documentdb_version }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -1,4 +1,10 @@
-name: RELEASE - Build Candidate Images
+name: "[DEPRECATED] RELEASE - Build Candidate Images"
+
+# ⚠️ DEPRECATED: This workflow builds ALL images (operator + sidecar + documentdb + gateway) together.
+# It has been replaced by two focused workflows:
+#   - build_operator_images.yml  → operator, sidecar (operator version track)
+#   - build_documentdb_images.yml → documentdb, gateway (database version track)
+# This workflow is kept for backward compatibility during transition.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build_operator_images.yml
+++ b/.github/workflows/build_operator_images.yml
@@ -1,0 +1,112 @@
+name: RELEASE - Build Operator Candidate Images
+
+# Builds operator and sidecar images from this repo's Go source.
+# These images follow the OPERATOR version track (Chart.appVersion).
+# For database images (documentdb extension + gateway), see build_documentdb_images.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Operator version for the build (will be tagged as {version}-test)'
+        required: false
+        default: '0.1.3'
+
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'operator/src/**'
+      - 'operator/cnpg-plugins/**'
+      - '.github/workflows/build_operator_images.yml'
+
+permissions:
+  packages: write
+  contents: read
+  id-token: write
+
+env:
+  VERSION: ${{ github.event.inputs.version || '0.1.3' }}
+  IMAGE_TAG: ${{ github.event.inputs.version || '0.1.3' }}-test
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Build and push operator + sidecar images (per-arch)
+  # ---------------------------------------------------------------------------
+  build-and-push:
+    name: Build and Push ${{ matrix.image.name }} (${{ matrix.arch }})
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        image:
+          - name: operator
+            dockerfile: operator/src/Dockerfile
+            context: operator/src/
+          - name: sidecar
+            dockerfile: operator/cnpg-plugins/sidecar-injector/Dockerfile
+            context: operator/cnpg-plugins/sidecar-injector/
+        include:
+          - arch: amd64
+            base_arch: AMD64
+            runner: ubuntu-22.04
+          - arch: arm64
+            base_arch: ARM64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Login to GHCR
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+    - name: Build and Push ${{ matrix.image.name }} (${{ matrix.arch }})
+      run: |
+        set -euo pipefail
+        TAG=${{ env.IMAGE_TAG }}-${{ matrix.arch }}
+        IMAGE=ghcr.io/${{ github.repository }}/${{ matrix.image.name }}:$TAG
+
+        docker build --build-arg ARCH=${{ matrix.base_arch }} \
+          -t $IMAGE \
+          -f ${{ matrix.image.dockerfile }} ${{ matrix.image.context }}
+        docker push $IMAGE
+
+  # ---------------------------------------------------------------------------
+  # Create multi-arch manifests, sign, and verify
+  # ---------------------------------------------------------------------------
+  create-manifest:
+    name: Create, Push, Sign & Verify Manifest (${{ matrix.image }})
+    strategy:
+      matrix:
+        image: [operator, sidecar]
+    runs-on: ubuntu-22.04
+    needs: [build-and-push]
+    steps:
+    - name: Login to GHCR
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+    - name: Create and Push Manifest
+      run: |
+        docker manifest create ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }} \
+          --amend ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}-amd64 \
+          --amend ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}-arm64
+        docker manifest push ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}
+
+    - name: Install cosign
+      uses: sigstore/cosign-installer@main
+
+    - name: Sign manifest (keyless)
+      run: |
+        DIGEST=$(docker buildx imagetools inspect ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }} \
+          | awk '/^Digest:/ { print $2 }')
+        echo "Signing manifest-list@${DIGEST}"
+        cosign sign ghcr.io/${{ github.repository }}/${{ matrix.image }}@${DIGEST} -y
+
+    - name: Verify manifest signature (keyless)
+      run: |
+        DIGEST=$(docker buildx imagetools inspect ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }} \
+          | awk '/^Digest:/ { print $2 }')
+        cosign verify \
+          --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/build_operator_images.yml@${{ github.ref }}" \
+          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+          ghcr.io/${{ github.repository }}/${{ matrix.image }}@${DIGEST}

--- a/.github/workflows/release_documentdb_images.yml
+++ b/.github/workflows/release_documentdb_images.yml
@@ -1,0 +1,161 @@
+name: RELEASE - Promote DocumentDB Images
+
+# Promotes documentdb extension and gateway candidate images to release tags,
+# then creates a PR to update default versions across the codebase.
+# This workflow handles only the DATABASE version track (documentDbVersion).
+# For operator/sidecar releases, see release_operator.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_version:
+        description: 'Database candidate tag to promote (e.g., 0.111.0-test)'
+        required: true
+        default: '0.110.0-test'
+      version:
+        description: 'Database image release version (e.g., 0.111.0)'
+        required: true
+        default: '0.110.0'
+      update_defaults:
+        description: 'Create PR to update default image versions in code'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Promote documentdb and gateway images (retag candidate → release)
+  # ---------------------------------------------------------------------------
+  promote-database-images:
+    name: Promote ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [documentdb, gateway]
+    steps:
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Verify candidate exists
+        run: |
+          echo "Verifying ${{ matrix.image }}:${{ inputs.candidate_version }} exists..."
+          docker buildx imagetools inspect \
+            ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ inputs.candidate_version }}
+
+      - name: Retag existing manifest
+        env:
+          SOURCE_TAG: ${{ inputs.candidate_version }}
+          TARGET_TAG: ${{ inputs.version }}
+        run: |
+          echo "Promoting ${{ matrix.image }} from $SOURCE_TAG to $TARGET_TAG"
+          docker buildx imagetools create \
+            -t ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.TARGET_TAG }} \
+            ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.SOURCE_TAG }}
+
+  # ---------------------------------------------------------------------------
+  # Update default versions in code and create PR
+  # ---------------------------------------------------------------------------
+  update-defaults:
+    name: Update Default Versions
+    runs-on: ubuntu-latest
+    needs: promote-database-images
+    if: ${{ inputs.update_defaults == true }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Detect current default version
+        id: current
+        run: |
+          # Extract current default from constants.go
+          CURRENT=$(grep 'DEFAULT_DOCUMENTDB_IMAGE' operator/src/internal/utils/constants.go \
+            | head -1 | sed -E 's/.*:([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          echo "current_version=$CURRENT" >> $GITHUB_OUTPUT
+          echo "Current default version: $CURRENT"
+
+      - name: Update version references
+        env:
+          OLD_VERSION: ${{ steps.current.outputs.current_version }}
+          NEW_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$OLD_VERSION" == "$NEW_VERSION" ]]; then
+            echo "Version $NEW_VERSION is already the default. No changes needed."
+            exit 0
+          fi
+
+          echo "Updating default versions: $OLD_VERSION → $NEW_VERSION"
+
+          # 1. Update operator constants.go
+          sed -i "s|:${OLD_VERSION}\"|:${NEW_VERSION}\"|g" \
+            operator/src/internal/utils/constants.go
+
+          # 2. Update sidecar plugin config.go
+          sed -i "s|:${OLD_VERSION}\"|:${NEW_VERSION}\"|g" \
+            operator/cnpg-plugins/sidecar-injector/internal/config/config.go
+
+          # 3. Update Helm chart values.yaml
+          sed -i "s|documentDbVersion: \"${OLD_VERSION}\"|documentDbVersion: \"${NEW_VERSION}\"|" \
+            operator/documentdb-helm-chart/values.yaml
+
+          # 4. Update test workflow fallback images
+          sed -i "s|documentdb:${OLD_VERSION}|documentdb:${NEW_VERSION}|g" \
+            .github/workflows/test-backup-and-restore.yml
+          sed -i "s|gateway:${OLD_VERSION}|gateway:${NEW_VERSION}|g" \
+            .github/workflows/test-backup-and-restore.yml
+
+          echo "=== Files modified ==="
+          git diff --name-only
+          echo ""
+          echo "=== Diff ==="
+          git diff
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: bump DocumentDB default images to ${{ inputs.version }}"
+          title: "chore: bump DocumentDB default images to ${{ inputs.version }}"
+          body: |
+            ## Automated DocumentDB Version Bump
+
+            Promoted images `documentdb` and `gateway` from candidate `${{ inputs.candidate_version }}` to release `${{ inputs.version }}`.
+
+            ### Changes
+            - Updated `DEFAULT_DOCUMENTDB_IMAGE` and `DEFAULT_GATEWAY_IMAGE` in `constants.go`
+            - Updated sidecar plugin default gateway image in `config.go`
+            - Updated `documentDbVersion` in Helm chart `values.yaml`
+            - Updated fallback images in `test-backup-and-restore.yml`
+
+            ### Image References
+            - `ghcr.io/${{ github.repository }}/documentdb:${{ inputs.version }}`
+            - `ghcr.io/${{ github.repository }}/gateway:${{ inputs.version }}`
+
+            ---
+            *Auto-generated by `release_documentdb_images.yml`*
+          branch: auto/documentdb-${{ inputs.version }}
+          delete-branch: true
+          labels: |
+            automated
+            version-bump
+
+      - name: Release summary
+        run: |
+          echo "## DocumentDB Image Release Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Database Version**: \`${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Images Promoted**: documentdb, gateway" >> $GITHUB_STEP_SUMMARY
+          echo "- **Source Tag**: \`${{ inputs.candidate_version }}\` → \`${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ steps.current.outputs.current_version }}" != "${{ inputs.version }}" ]]; then
+            echo "- **PR Created**: Updates default versions from \`${{ steps.current.outputs.current_version }}\` to \`${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- **No PR needed**: Version \`${{ inputs.version }}\` is already the default" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/release_operator.yml
+++ b/.github/workflows/release_operator.yml
@@ -1,22 +1,20 @@
-name: "[DEPRECATED] RELEASE - Promote Candidate Images and Publish Helm Chart"
+name: RELEASE - Promote Operator Images and Publish Helm Chart
 
-# ⚠️ DEPRECATED: This workflow promotes ALL images and publishes the Helm chart together.
-# It has been replaced by two focused workflows:
-#   - release_operator.yml          → promotes operator/sidecar, publishes Helm chart
-#   - release_documentdb_images.yml → promotes documentdb/gateway, auto-PRs version bumps
-# This workflow is kept for backward compatibility during transition.
+# Promotes operator/sidecar candidate images to release tags and publishes the Helm chart.
+# This workflow handles only the OPERATOR version track (Chart.appVersion).
+# For database image releases (documentdb + gateway), see release_documentdb_images.yml.
 
 on:
   workflow_dispatch:
     inputs:
       candidate_version:
-        description: 'Version of the build candidate to promote (will be tagged as {version})'
+        description: 'Operator candidate tag to promote (e.g., 0.1.3-test)'
         required: true
-        default: '0.1.1-test'
+        default: '0.1.3-test'
       version:
-        description: 'Version to release (used for images and Helm chart)'
+        description: 'Release version for operator images and Helm chart'
         required: true
-        default: '0.1.1'
+        default: '0.1.3'
       source_ref:
         description: 'Git ref to package the Helm chart from (tag or commit recommended to avoid drift)'
         required: true
@@ -33,7 +31,9 @@ permissions:
   id-token: write
 
 jobs:
-  # Optional test jobs - run both E2E and integration tests in parallel if enabled
+  # ---------------------------------------------------------------------------
+  # Optional test gate — run E2E, integration, and backup tests in parallel
+  # ---------------------------------------------------------------------------
   test-e2e:
     name: E2E Test Images Before Release
     if: ${{ inputs.run_tests == true }}
@@ -58,33 +58,39 @@ jobs:
       image_tag: ${{ inputs.candidate_version }}
     secrets: inherit
 
-  copy-and-push-manifest:
-    name: Release Images
+  # ---------------------------------------------------------------------------
+  # Promote operator and sidecar images (retag candidate → release)
+  # ---------------------------------------------------------------------------
+  promote-operator-images:
+    name: Promote ${{ matrix.image }}
     runs-on: ubuntu-latest
     needs: [test-e2e, test-integration, test-backup-and-restore]
     if: ${{ always() && (needs.test-e2e.result == 'success' || needs.test-e2e.result == 'skipped') && (needs.test-integration.result == 'success' || needs.test-integration.result == 'skipped') && (needs.test-backup-and-restore.result == 'success' || needs.test-backup-and-restore.result == 'skipped') }}
     strategy:
       matrix:
-        image: [operator, sidecar, documentdb, gateway]
+        image: [operator, sidecar]
     steps:
       - name: Login to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Retag existing manifest
         env:
-          SOURCE_TAG: ${{ github.event.inputs.candidate_version }}
-          TARGET_TAG: ${{ github.event.inputs.version }}
+          SOURCE_TAG: ${{ inputs.candidate_version }}
+          TARGET_TAG: ${{ inputs.version }}
         run: |
-          echo "Releasing ${{ matrix.image }} image from tag $SOURCE_TAG to $TARGET_TAG"
+          echo "Promoting ${{ matrix.image }} from $SOURCE_TAG to $TARGET_TAG"
           docker buildx imagetools create \
             -t ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.TARGET_TAG }} \
             ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.SOURCE_TAG }}
 
+  # ---------------------------------------------------------------------------
+  # Package and publish Helm chart
+  # ---------------------------------------------------------------------------
   publish-helm-chart:
     name: Publish Helm Chart
     runs-on: ubuntu-latest
-    needs: copy-and-push-manifest
-    if: ${{ always() && needs.copy-and-push-manifest.result == 'success' }}
+    needs: promote-operator-images
+    if: ${{ always() && needs.promote-operator-images.result == 'success' }}
     permissions:
       contents: read
       id-token: write
@@ -101,21 +107,26 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
 
-      - name: Update values.yaml with version tag
-        run: |
-          echo "Chart uses Chart.appVersion for image tags (no tag: field in values.yaml)"
-          echo "values.yaml content:"
-          cat operator/documentdb-helm-chart/values.yaml
-
       - name: Set chart version
         run: |
-            echo "CHART_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-            echo "Using chart version: ${{ github.event.inputs.version }}"
+            echo "CHART_VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+            echo "Using chart version: ${{ inputs.version }}"
 
       - name: Update Chart.yaml metadata
         run: |
           sed -i "s/^version: .*/version: ${CHART_VERSION}/" operator/documentdb-helm-chart/Chart.yaml
           sed -i "s/^appVersion: .*/appVersion: \"${CHART_VERSION}\"/" operator/documentdb-helm-chart/Chart.yaml
+          echo "Chart.yaml after update:"
+          cat operator/documentdb-helm-chart/Chart.yaml
+
+      - name: Verify values.yaml has explicit documentDbVersion
+        run: |
+          DOCDB_VERSION=$(grep 'documentDbVersion:' operator/documentdb-helm-chart/values.yaml | sed 's/.*"\(.*\)".*/\1/')
+          if [[ -z "$DOCDB_VERSION" || "$DOCDB_VERSION" == '""' ]]; then
+            echo "WARNING: documentDbVersion is empty in values.yaml. Database images will use compiled defaults."
+          else
+            echo "documentDbVersion is set to: $DOCDB_VERSION"
+          fi
 
       - name: Package Helm chart
         run: |
@@ -128,21 +139,24 @@ jobs:
 
       - name: Push Helm chart to GHCR
         run: |
-          helm push /home/runner/work/documentdb-kubernetes-operator/documentdb-kubernetes-operator/documentdb-operator-${CHART_VERSION}.tgz oci://${GHCR_REPO}
+          CHART_FILE=$(ls documentdb-operator-${CHART_VERSION}.tgz 2>/dev/null || ls */documentdb-operator-${CHART_VERSION}.tgz 2>/dev/null)
+          helm push "$CHART_FILE" oci://${GHCR_REPO}
 
-      - name: Helm release summary
+      - name: Release summary
         run: |
-          echo "## Helm Chart Release Summary" >> $GITHUB_STEP_SUMMARY
+          echo "## Operator Release Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Chart Name**: \`$CHART_NAME\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version**: \`$CHART_VERSION\` (unified for chart and images)" >> $GITHUB_STEP_SUMMARY
-          echo "- **Chart Source Ref**: \`${{ github.event.inputs.source_ref }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Source Tag**: \`${{ github.event.inputs.candidate_version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Target Tag**: \`${{ github.event.inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Operator Version**: \`$CHART_VERSION\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Images Promoted**: operator, sidecar" >> $GITHUB_STEP_SUMMARY
+          echo "- **Source Tag**: \`${{ inputs.candidate_version }}\` → \`${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Chart Source Ref**: \`${{ inputs.source_ref }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Registry**: \`$GHCR_REPO\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Note**: Images promoted from \`${{ github.event.inputs.candidate_version }}\` to \`${{ github.event.inputs.version }}\` and Helm chart published" >> $GITHUB_STEP_SUMMARY
+          echo "**Note**: Database images (documentdb, gateway) are released independently via \`release_documentdb_images.yml\`." >> $GITHUB_STEP_SUMMARY
 
+  # ---------------------------------------------------------------------------
+  # Publish Helm repository to GitHub Pages
+  # ---------------------------------------------------------------------------
   publish-helm-pages:
     name: Publish Helm Repository
     needs: publish-helm-chart
@@ -158,7 +172,5 @@ jobs:
       dry_run: false
       confirm_version: ${{ inputs.version }}
       normalize_chart_metadata: true
-      # Follow the same gh-pages branch used by mike in deploy_docs.yml.
       allow_pages_source_mismatch: true
     secrets: inherit
-  

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,11 +59,25 @@ The DocumentDB Kubernetes Operator is a Kubernetes operator that manages Documen
 | Component | Version | Notes |
 |-----------|---------|-------|
 | Kubernetes | 1.30+ | Based on k8s.io/api v0.34.2 |
-| CloudNative-PG | 1.28.0 | Helm chart uses CNPG chart 0.26.1 |
+| CloudNative-PG | 1.28.0 | Helm chart uses CNPG chart 0.27.0 |
 | cert-manager | 1.19.2 | Required for TLS certificate management |
 | controller-runtime | 0.22.4 | Kubebuilder framework |
 | Go | 1.25.0 | See `operator/src/go.mod` |
 | Helm | 3.x | Required for deployment |
+
+### Image Version Tracks
+
+The project uses **two independent version tracks** for container images:
+
+| Track | Images | Version Source | Tag Example |
+|-------|--------|---------------|-------------|
+| **Operator** | operator, sidecar, wal-replica | `Chart.appVersion` | `0.1.3` |
+| **Database** | documentdb (extension), gateway | `values.yaml` → `documentDbVersion` | `0.110.0` |
+
+- Operator images are built from this repo's Go source
+- Database images are built from upstream `documentdb/documentdb` `.deb` packages
+- Each track has its own build and release workflows
+- Database image defaults are also hardcoded in `constants.go` and `config.go` as fallbacks
 
 > **Note:** When the project moves to GA, maintain a separate version compatibility matrix for each release to track dependency versions across operator releases.
 
@@ -268,8 +282,12 @@ Types:
 - `test-integration.yml` - Integration tests
 - `test-E2E.yml` - End-to-end tests
 - `test-backup-and-restore.yml` - Backup feature tests
-- `build_images.yml` - Docker image builds
-- `release_images.yml` - Release automation
+- `build_operator_images.yml` - Build operator/sidecar candidate images (operator version track)
+- `build_documentdb_images.yml` - Build documentdb/gateway candidate images (database version track)
+- `release_operator.yml` - Promote operator/sidecar images and publish Helm chart
+- `release_documentdb_images.yml` - Promote documentdb/gateway images and auto-PR version bumps
+- `build_images.yml` - [DEPRECATED] Combined image builds (replaced by split workflows above)
+- `release_images.yml` - [DEPRECATED] Combined release (replaced by split workflows above)
 - `deploy_docs.yml` - Documentation deployment
 
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -69,8 +69,19 @@ This creates a branch `release/v{version}` and opens a PR.
 
 After the PR is approved and merged:
 
-1. Run **"RELEASE - Build Candidate Images"** workflow with the version number
-2. Run **"RELEASE - Promote Candidate Images and Publish Helm Chart"** workflow to publish
+#### Operator Release (operator + sidecar images + Helm chart)
+
+1. Run **"RELEASE - Build Operator Candidate Images"** (`build_operator_images.yml`) with the operator version
+2. Run **"RELEASE - Promote Operator Images and Publish Helm Chart"** (`release_operator.yml`) to promote and publish
+
+#### Database Image Release (documentdb extension + gateway)
+
+Database images follow an **independent release cycle** from the operator:
+
+1. Run **"RELEASE - Build DocumentDB Candidate Images"** (`build_documentdb_images.yml`) with the upstream `documentdb_ref`
+2. Run **"RELEASE - Promote DocumentDB Images"** (`release_documentdb_images.yml`) to promote and auto-create a PR that bumps default image versions across the codebase
+
+> **Note:** The deprecated combined workflows (`build_images.yml`, `release_images.yml`) are still available but will be removed in a future release.
 
 ---
 

--- a/docs/designs/image-management.md
+++ b/docs/designs/image-management.md
@@ -1,0 +1,421 @@
+# Container Image Management
+
+This document describes how the DocumentDB Kubernetes Operator manages, builds, versions, and releases container images.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Image Inventory](#image-inventory)
+- [Version Tracks](#version-tracks)
+- [How the Operator Resolves Images at Runtime](#how-the-operator-resolves-images-at-runtime)
+- [Helm Chart Configuration](#helm-chart-configuration)
+- [Build Pipelines](#build-pipelines)
+- [Release Pipelines](#release-pipelines)
+- [Test Pipelines](#test-pipelines)
+- [Local Development](#local-development)
+- [Version Synchronization Points](#version-synchronization-points)
+- [Architecture Support](#architecture-support)
+- [Security](#security)
+
+---
+
+## Overview
+
+The project manages **5 container images** across two independent version tracks:
+
+- **Operator track**: images built from Go source code in this repository
+- **Database track**: images built from `.deb` packages produced by the upstream [`documentdb/documentdb`](https://github.com/documentdb/documentdb) repository
+
+All images are published to **GitHub Container Registry (GHCR)** under `ghcr.io/documentdb/documentdb-kubernetes-operator/`. A sixth image (PostgreSQL) comes from the CloudNative-PG project and is consumed as-is.
+
+---
+
+## Image Inventory
+
+### Operator Track — Built from This Repository
+
+| Image | GHCR Path | Source | Dockerfile | Purpose |
+|-------|-----------|--------|------------|---------|
+| **operator** | `.../operator` | `operator/src/` (Go) | `operator/src/Dockerfile` | Main reconciliation controller for DocumentDB CRDs |
+| **sidecar** | `.../sidecar` | `operator/cnpg-plugins/sidecar-injector/` (Go) | `operator/cnpg-plugins/sidecar-injector/Dockerfile` | CNPG plugin that injects the gateway sidecar into database pods |
+| **wal-replica** | `.../wal-replica` | `operator/cnpg-plugins/wal-replica/` (Go) | *(planned)* | WAL-based read replica plugin (feature-flagged, disabled by default) |
+
+### Database Track — Built from External Source
+
+| Image | GHCR Path | Source | Dockerfile | Purpose |
+|-------|-----------|--------|------------|---------|
+| **documentdb** | `.../documentdb` | `.deb` from `documentdb/documentdb` | `.github/dockerfiles/Dockerfile_extension` | DocumentDB PostgreSQL extension files for CNPG ImageVolume mode |
+| **gateway** | `.../gateway` | `.deb` from `documentdb/documentdb` | `.github/dockerfiles/Dockerfile_gateway_deb` | MongoDB wire-protocol gateway binary (Rust) |
+
+### External Image (Not Built Here)
+
+| Image | Full Reference | Source | Purpose |
+|-------|---------------|--------|---------|
+| **PostgreSQL** | `ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie` | CloudNative-PG project | Base PostgreSQL server image for CNPG clusters |
+
+---
+
+## Version Tracks
+
+The two version tracks are **independent** — they follow different release cadences and use different version numbering.
+
+| Aspect | Operator Track | Database Track |
+|--------|---------------|----------------|
+| **Images** | operator, sidecar, wal-replica | documentdb, gateway |
+| **Source repo** | This repo (Go) | `documentdb/documentdb` (C + Rust) |
+| **Version source** | `Chart.appVersion` in `Chart.yaml` | `documentDbVersion` in `values.yaml` |
+| **Current version** | `0.1.3` | `0.110.0` |
+| **Build workflow** | `build_operator_images.yml` | `build_documentdb_images.yml` |
+| **Release workflow** | `release_operator.yml` | `release_documentdb_images.yml` |
+| **Tag example** | `ghcr.io/.../operator:0.1.3` | `ghcr.io/.../documentdb:0.110.0` |
+
+### Why Two Tracks?
+
+The DocumentDB extension and gateway are developed in a separate repository (`documentdb/documentdb`) and iterate at a different cadence than the Kubernetes operator. Decoupling allows:
+
+- Operator bug fixes without rebuilding database images (~2 min vs ~15+ min)
+- Database upgrades without a full operator release
+- Image tags that reflect actual component versions
+- Independent testing and promotion pipelines
+
+---
+
+## How the Operator Resolves Images at Runtime
+
+The operator binary determines which database images to use through a priority chain. This logic lives in `operator/src/internal/utils/util.go`.
+
+### DocumentDB Extension Image (`GetDocumentDBImageForInstance()`)
+
+```
+Priority (highest → lowest):
+1. spec.documentDBImage          ← CR field: full image URI override
+2. spec.documentDBVersion        ← CR field: used as tag with hardcoded repo
+3. env DOCUMENTDB_VERSION        ← from Helm chart (documentDbVersion in values.yaml)
+4. ChangeStreams feature gate     ← temporary override for changestream images
+5. DEFAULT_DOCUMENTDB_IMAGE      ← compiled-in default (constants.go)
+```
+
+### Gateway Image (`GetGatewayImageForDocumentDB()`)
+
+```
+Priority (highest → lowest):
+1. spec.gatewayImage             ← CR field: full image URI override
+2. spec.documentDBVersion        ← CR field: used as tag with hardcoded repo
+3. env DOCUMENTDB_VERSION        ← from Helm chart (documentDbVersion in values.yaml)
+4. ChangeStreams feature gate     ← temporary override for changestream images
+5. DEFAULT_GATEWAY_IMAGE          ← compiled-in default (constants.go)
+```
+
+### PostgreSQL Image
+
+Set via `spec.postgresImage` in the DocumentDB CR. Defaults to `ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie` (hardcoded in the CRD schema).
+
+### How Images Flow into Pods
+
+```
+DocumentDB CR spec
+    │
+    ▼
+Operator controller (documentdb_controller.go)
+    ├── Resolves documentdbImage via GetDocumentDBImageForInstance()
+    ├── Resolves gatewayImage via GetGatewayImageForDocumentDB()
+    │
+    ▼
+CNPG Cluster spec (cnpg_cluster.go)
+    ├── documentdbImage → ImageVolumeSource (mounted as read-only volume)
+    ├── gatewayImage → passed as plugin parameter to sidecar-injector
+    │
+    ▼
+Sidecar Injector Plugin (lifecycle.go)
+    └── Reads gatewayImage from plugin parameters
+        └── Injects gateway container with that image into each database pod
+```
+
+---
+
+## Helm Chart Configuration
+
+The Helm chart (`operator/documentdb-helm-chart/`) coordinates deployment of operator-track images and passes database version configuration to the operator.
+
+### Chart.yaml
+
+```yaml
+version: 0.1.3           # Chart version
+appVersion: "0.1.3"       # Default tag for operator/sidecar/wal-replica images
+```
+
+### values.yaml
+
+```yaml
+# Database image version (extension + gateway) — independent of Chart.appVersion
+documentDbVersion: "0.110.0"
+
+image:
+  documentdbk8soperator:
+    repository: ghcr.io/documentdb/documentdb-kubernetes-operator/operator
+    pullPolicy: Always
+  sidecarinjector:
+    repository: ghcr.io/documentdb/documentdb-kubernetes-operator/sidecar
+    pullPolicy: Always
+  walreplica:
+    repository: ghcr.io/documentdb/documentdb-kubernetes-operator/wal-replica
+    pullPolicy: Always
+```
+
+### Image Tag Resolution in Templates
+
+**Operator-track images** use `Chart.AppVersion`:
+```yaml
+image: "{{ .Values.image.documentdbk8soperator.repository }}:{{ .Values.image.documentdbk8soperator.tag | default .Chart.AppVersion }}"
+```
+
+**Database version** is passed as an environment variable:
+```yaml
+{{- if .Values.documentDbVersion }}
+- name: DOCUMENTDB_VERSION
+  value: "{{ .Values.documentDbVersion }}"
+{{- end }}
+```
+
+The `DOCUMENTDB_VERSION` env var feeds into the operator's image resolution chain (priority 3). If not set, the operator uses its compiled-in defaults.
+
+---
+
+## Build Pipelines
+
+### Operator Image Build (`build_operator_images.yml`)
+
+Builds operator and sidecar images from this repo's Go source.
+
+| Aspect | Details |
+|--------|---------|
+| **Trigger** | `workflow_dispatch`, `push` to `main` (operator source paths) |
+| **Images** | operator, sidecar |
+| **Dockerfiles** | `operator/src/Dockerfile`, `operator/cnpg-plugins/sidecar-injector/Dockerfile` |
+| **Tag pattern** | `{version}-test` (candidate), `{version}-test-{arch}` (per-arch) |
+| **Build time** | ~2 minutes |
+| **Multi-arch** | amd64 + arm64 → multi-arch manifest |
+| **Signing** | cosign keyless (OIDC) |
+
+### Database Image Build (`build_documentdb_images.yml`)
+
+Builds documentdb extension and gateway images from upstream `.deb` packages.
+
+| Aspect | Details |
+|--------|---------|
+| **Trigger** | `workflow_dispatch`, `repository_dispatch` (from upstream) |
+| **Images** | documentdb, gateway |
+| **Dockerfiles** | `.github/dockerfiles/Dockerfile_extension`, `.github/dockerfiles/Dockerfile_gateway_deb` |
+| **Tag pattern** | `{documentdb_version}-test` (candidate) |
+| **Build time** | ~15+ minutes (C/Rust .deb compilation) |
+| **Multi-arch** | amd64 + arm64 → multi-arch manifest |
+| **Signing** | cosign keyless (OIDC) |
+| **Version detection** | Auto-extracted from `pg_documentdb_core/documentdb_core.control` |
+
+The build process:
+1. Checks out `documentdb/documentdb` at a configurable git ref
+2. Runs `./packaging/build_packages.sh` to produce extension `.deb`
+3. Runs `./packaging/build_gateway_packages.sh` to produce gateway `.deb`
+4. Builds `Dockerfile_extension` using the extension `.deb` (installs pg_cron, pgvector, postgis alongside)
+5. Builds `Dockerfile_gateway_deb` using the gateway `.deb`
+
+### Dockerfile Details
+
+#### Operator (`operator/src/Dockerfile`)
+- **Base**: `mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0` → `scratch`
+- **Multi-stage**: 2 stages (builder → scratch)
+- **Entrypoint**: `/manager`
+
+#### Sidecar (`operator/cnpg-plugins/sidecar-injector/Dockerfile`)
+- **Base**: Same Go Azure Linux image → `scratch`
+- **Multi-stage**: 2 stages
+- **Entrypoint**: `/app/bin/cnpg-i-sidecar-injector`
+
+#### DocumentDB Extension (`.github/dockerfiles/Dockerfile_extension`)
+- **Base**: `ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie` → `scratch`
+- **Multi-stage**: 2 stages
+- **No entrypoint** — this is an ImageVolume source, not a runnable container
+- Follows the [cloudnative-pg/postgres-extensions-containers](https://github.com/cloudnative-pg/postgres-extensions-containers) pattern
+- Installs DocumentDB extension + pg_cron + pgvector + PostGIS
+- Copies only extension artifacts (`.so`, `.control`, `.sql`, bitcode) and required system libraries
+- Resolves Debian-alternatives symlinks (they break in ImageVolume mode)
+
+#### Gateway (`.github/dockerfiles/Dockerfile_gateway_deb`)
+- **Base**: `debian:trixie-slim`
+- **Single stage**
+- **Entrypoint**: `/bin/bash /home/documentdb/gateway/scripts/gateway_entrypoint.sh`
+- Runs as non-root `documentdb` user (UID 1000)
+
+---
+
+## Release Pipelines
+
+### Operator Release (`release_operator.yml`)
+
+Promotes operator/sidecar candidate images and publishes the Helm chart.
+
+```
+Inputs:
+  candidate_version: "0.1.3-test"   ← source tag
+  version: "0.1.3"                  ← target release tag
+  source_ref: <git tag or commit>   ← for Helm chart packaging
+
+Flow:
+  1. Test Gate (optional, parallel)
+     ├── test-E2E.yml
+     ├── test-integration.yml
+     └── test-backup-and-restore.yml
+  
+  2. Promote Images
+     └── docker buildx imagetools create
+         -t .../operator:0.1.3  .../operator:0.1.3-test
+         -t .../sidecar:0.1.3   .../sidecar:0.1.3-test
+  
+  3. Publish Helm Chart
+     ├── Update Chart.yaml (version + appVersion)
+     ├── helm package + helm push to oci://ghcr.io/{owner}
+     └── Publish to GitHub Pages (Helm repo index)
+```
+
+### Database Image Release (`release_documentdb_images.yml`)
+
+Promotes documentdb/gateway candidate images and auto-creates a PR to update defaults.
+
+```
+Inputs:
+  candidate_version: "0.111.0-test"   ← source tag
+  version: "0.111.0"                  ← target release tag
+  update_defaults: true               ← create PR to bump versions
+
+Flow:
+  1. Promote Images
+     └── docker buildx imagetools create
+         -t .../documentdb:0.111.0  .../documentdb:0.111.0-test
+         -t .../gateway:0.111.0     .../gateway:0.111.0-test
+  
+  2. Update Defaults (auto-PR)
+     ├── constants.go: DEFAULT_DOCUMENTDB_IMAGE, DEFAULT_GATEWAY_IMAGE
+     ├── config.go: sidecar plugin default gateway image
+     ├── values.yaml: documentDbVersion
+     ├── test-backup-and-restore.yml: fallback images
+     └── Opens PR: "chore: bump DocumentDB images to 0.111.0"
+```
+
+---
+
+## Test Pipelines
+
+### Test Build (`test-build-and-package.yml`)
+
+Reusable workflow that builds ALL images (operator + database) locally for test validation. Called by all test workflows when no external `image_tag` is provided.
+
+- All images share a single test tag: `{version}-test-{run_id}-{arch}`
+- Images are built with `--load` and saved as `.tar` artifacts (not pushed to GHCR)
+- Also produces arch-specific Helm chart packages
+
+### Test Workflows
+
+| Workflow | Trigger | Special Image Logic |
+|----------|---------|---------------------|
+| `test-E2E.yml` | push/PR/schedule/dispatch | Standard — local build or external images |
+| `test-integration.yml` | push/PR/dispatch | Standard — local build or external images |
+| `test-backup-and-restore.yml` | push/PR/schedule/dispatch | Has hardcoded fallback images for external mode |
+| `test-upgrade-and-rollback.yml` | push/PR/schedule/dispatch | Old/new image comparison; combined image for chart ≤0.1.3 |
+| `test-unit.yml` | push/PR | No container images |
+
+### Image Loading (`setup-test-environment` action)
+
+The `.github/actions/setup-test-environment/action.yml` composite action handles loading images into Kind clusters:
+
+- **Local build path**: `docker load` from `.tar` → `kind load docker-image`
+- **External image path**: `docker pull` from GHCR → `kind load docker-image`
+- Supports separate `documentdb-image-tag` for independent database image versioning in tests
+- Falls back to `image-tag` (operator tag) for backward compatibility
+
+---
+
+## Local Development
+
+### Makefile Targets (`operator/src/Makefile`)
+
+```bash
+make docker-build    # Build operator image: docker build -t ${IMG} .
+make docker-push     # Push operator image
+make docker-buildx   # Multi-platform build and push
+```
+
+### Deploy Script (`operator/src/scripts/development/deploy.sh`)
+
+```bash
+# Defaults
+REGISTRY=localhost:5001
+OPERATOR_IMAGE=${REGISTRY}/operator
+PLUGIN_IMAGE=${REGISTRY}/sidecar-injector
+TAG=0.1.1
+
+# Usage: builds and deploys to a local Kind cluster
+DEPLOY=true DEPLOY_CLUSTER=true ./scripts/development/deploy.sh
+```
+
+The script uses `kind_with_registry.sh` to set up a `registry:2` container on `localhost:5001`, connected to the Kind cluster's network.
+
+---
+
+## Version Synchronization Points
+
+When bumping database image versions, the following locations must be updated (automated by `release_documentdb_images.yml`):
+
+| File | Field | Example |
+|------|-------|---------|
+| `operator/src/internal/utils/constants.go` | `DEFAULT_DOCUMENTDB_IMAGE` | `...documentdb:0.110.0` |
+| `operator/src/internal/utils/constants.go` | `DEFAULT_GATEWAY_IMAGE` | `...gateway:0.110.0` |
+| `operator/cnpg-plugins/sidecar-injector/internal/config/config.go` | Default gateway image | `...gateway:0.110.0` |
+| `operator/documentdb-helm-chart/values.yaml` | `documentDbVersion` | `"0.110.0"` |
+| `.github/workflows/test-backup-and-restore.yml` | `DOCUMENTDB_IMAGE`, `GATEWAY_IMAGE` env | `...documentdb:0.110.0` |
+
+When bumping operator versions, update:
+
+| File | Field | Example |
+|------|-------|---------|
+| `operator/documentdb-helm-chart/Chart.yaml` | `version`, `appVersion` | `0.1.3` |
+| `CHANGELOG.md` | New version entry | `## [0.1.3]` |
+
+> **Note**: The `constants.go` and `config.go` defaults must be kept in sync — this is enforced by a `NOTE: Keep in sync` comment in both files.
+
+---
+
+## Architecture Support
+
+All images support multi-architecture builds:
+
+| Platform | CI Runner | Notes |
+|----------|-----------|-------|
+| `linux/amd64` | `ubuntu-22.04` | Primary architecture |
+| `linux/arm64` | `ubuntu-22.04-arm` | ARM support |
+
+Build workflows produce per-arch images with `-amd64`/`-arm64` suffixes, then create multi-arch manifests using `docker manifest create --amend`.
+
+---
+
+## Security
+
+| Aspect | Implementation |
+|--------|---------------|
+| **Image signing** | cosign keyless (OIDC-based) during build workflows |
+| **Signature verification** | Certificate identity matching in the same workflow |
+| **Minimal images** | Operator/sidecar use `scratch`; extension uses `scratch`; gateway uses `debian:trixie-slim` |
+| **Non-root execution** | Gateway: UID 1000 (`documentdb`); operator/sidecar: from `scratch` with no shell |
+| **No pull secrets** | GHCR public packages; no `imagePullSecrets` in chart |
+
+---
+
+## Deprecated Workflows
+
+The following workflows are deprecated and will be removed in a future release:
+
+| Deprecated | Replaced By |
+|-----------|-------------|
+| `build_images.yml` | `build_operator_images.yml` + `build_documentdb_images.yml` |
+| `release_images.yml` | `release_operator.yml` + `release_documentdb_images.yml` |
+
+The deprecated workflows built and released all 4 images together, coupling the operator and database version tracks. The new split workflows allow independent release cycles.

--- a/operator/documentdb-helm-chart/Chart.yaml
+++ b/operator/documentdb-helm-chart/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v2
 name: documentdb-operator
 version: 0.1.3
 description: A Helm chart for deploying the DocumentDB operator
-# appVersion represents the default DocumentDB version for this chart release
+# appVersion controls the default image tag for operator, sidecar, and wal-replica images.
+# Database image versions (documentdb extension + gateway) are controlled by documentDbVersion in values.yaml.
 appVersion: "0.1.3"
 dependencies:
   - name: cloudnative-pg

--- a/operator/documentdb-helm-chart/templates/02_documentdb_sidecar_injector.yaml
+++ b/operator/documentdb-helm-chart/templates/02_documentdb_sidecar_injector.yaml
@@ -45,13 +45,13 @@ spec:
         - --server-key=/server/tls.key
         - --client-cert=/client/tls.crt
         - --server-address=:9090
-        image: "{{ .Values.image.sidecarinjector.repository }}:{{ .Values.image.sidecarinjector.tag | default .Values.documentDbVersion | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.sidecarinjector.repository }}:{{ .Values.image.sidecarinjector.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.sidecarinjector.pullPolicy }}"
         name: cnpg-i-sidecar-injector
         env:
-        {{- if .Values.documentDbVersion | default .Chart.AppVersion }}
+        {{- if .Values.documentDbVersion }}
         - name: DOCUMENTDB_VERSION
-          value: "{{ .Values.documentDbVersion | default .Chart.AppVersion }}"
+          value: "{{ .Values.documentDbVersion }}"
         {{- end }}
         ports:
         - containerPort: 9090

--- a/operator/documentdb-helm-chart/templates/03_documentdb_wal_replica.yaml
+++ b/operator/documentdb-helm-chart/templates/03_documentdb_wal_replica.yaml
@@ -90,7 +90,7 @@ spec:
     spec:
       serviceAccountName: wal-replica-manager
       containers:
-      - image: "{{ .Values.image.walreplica.repository }}:{{ .Values.image.walreplica.tag | default .Values.documentDbVersion | default .Chart.AppVersion }}"  
+      - image: "{{ .Values.image.walreplica.repository }}:{{ .Values.image.walreplica.tag | default .Chart.AppVersion }}"  
         imagePullPolicy: "{{ .Values.image.walreplica.pullPolicy }}"
         name: cnpg-i-wal-replica
         ports:

--- a/operator/documentdb-helm-chart/templates/09_documentdb_operator.yaml
+++ b/operator/documentdb-helm-chart/templates/09_documentdb_operator.yaml
@@ -20,14 +20,14 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
       - name: documentdb-operator
-        image: "{{ .Values.image.documentdbk8soperator.repository }}:{{ .Values.image.documentdbk8soperator.tag | default .Values.documentDbVersion | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.documentdbk8soperator.repository }}:{{ .Values.image.documentdbk8soperator.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.documentdbk8soperator.pullPolicy }}"
         env:
         - name: GATEWAY_PORT
           value: "10260"
-        {{- if .Values.documentDbVersion | default .Chart.AppVersion }}
+        {{- if .Values.documentDbVersion }}
         - name: DOCUMENTDB_VERSION
-          value: "{{ .Values.documentDbVersion | default .Chart.AppVersion }}"
+          value: "{{ .Values.documentDbVersion }}"
         {{- end }}
         {{- if .Values.gatewayImagePullPolicy }}
         - name: GATEWAY_IMAGE_PULL_POLICY

--- a/operator/documentdb-helm-chart/values.yaml
+++ b/operator/documentdb-helm-chart/values.yaml
@@ -1,10 +1,12 @@
 namespace: documentdb-operator
 replicaCount: 1
 
-# DocumentDB version - global default for all components when individual tags are not set
-# Priority: individual component tag > documentDbVersion > Chart.appVersion
-# Defaults to Chart.appVersion if not specified  
-documentDbVersion: ""
+# DocumentDB database image version (extension + gateway images).
+# This controls the DOCUMENTDB_VERSION env var passed to the operator and sidecar,
+# which determines the default documentdb extension and gateway image tags at runtime.
+# This version is INDEPENDENT of Chart.appVersion (which controls operator/sidecar image tags).
+# When empty, the operator falls back to its compiled-in defaults (see constants.go).
+documentDbVersion: "0.110.0"
 
 # Gateway image pull policy for the gateway sidecar container.
 # Valid values: Always, IfNotPresent, Never. Defaults to IfNotPresent if not set.


### PR DESCRIPTION
Decouple image management into independent operator and database tracks.

Changes:
- split operator and database build/release workflows
- decouple Helm chart image version handling
- deprecate the old combined workflows
- add image-management design documentation

Validation:
- helm lint operator/documentdb-helm-chart/
- go test ./... in operator/src
- go test ./... in operator/cnpg-plugins/sidecar-injector
