### PR TITLE
fix: use repo pages URL for helm release

### DIFF
--- a/.github/workflows/release_operator.yml
+++ b/.github/workflows/release_operator.yml
@@ -241,7 +241,7 @@ jobs:
       version: ${{ inputs.version }}
       release_ref: ${{ inputs.source_ref }}
       publish_branch: gh-pages
-      repo_url: https://documentdb.github.io/documentdb-kubernetes-operator
+      repo_url: ${{ format('https://{0}.github.io/{1}', github.repository_owner, github.event.repository.name) }}
       dry_run: false
       confirm_version: ${{ inputs.version }}
       normalize_chart_metadata: true


### PR DESCRIPTION
## Summary
- use the current repository Pages URL when republishing the Helm repository during operator releases
- make fork releases publish chart metadata against the fork Pages site instead of the upstream URL

## Why
The operator release workflow currently hardcodes the upstream Pages URL. On a fork, that would generate the wrong Helm repository output during release e2e validation.